### PR TITLE
add QC filter for seqs with excessive substitution mutations

### DIFF
--- a/web/src/components/ReportMethodology.vue
+++ b/web/src/components/ReportMethodology.vue
@@ -37,6 +37,9 @@
           Sequences with lengths &le; 20,000 base pairs were removed from the analysis.
         </li>
         <li>
+          Sequences with more than 5000 nucleotide substitutions.
+        </li>
+        <li>
           Sequences with a contiguous deletion spanning > 500 base pairs were removed from the analysis.
         </li>
       </ul>


### PR DESCRIPTION
Added bullet point about additional QC step that filters out sequences with excessive number of substitution mutations (>5000)