### PR TITLE
hotfix: disable scroll null issue in location report page

### DIFF
--- a/web/src/components/LocationReportComponent.vue
+++ b/web/src/components/LocationReportComponent.vue
@@ -801,7 +801,7 @@
                     <router-link
                       :to="{
                         name: 'MutationReport',
-                        params: choro.params,
+                        params: choro.params ? choro.params : {},
                         query: { ...choro.route, loc: [loc], selected: loc },
                       }"
                     >


### PR DESCRIPTION
- In location report page, there is an error in case of United kingdom.

![image](https://user-images.githubusercontent.com/92925885/206078016-a33df603-cbbb-4018-bd39-d165735ed601.png)
