### PR TITLE
Location report UI improvements

### DIFF
--- a/web/src/components/HorizontalCategoricalLegend.vue
+++ b/web/src/components/HorizontalCategoricalLegend.vue
@@ -3,7 +3,7 @@
     <svg
       v-for="(value, vIdx) in legendValues"
       :key="vIdx"
-      :width="80"
+      :width="82"
       :height="legendRectWidth + 2"
       class="categorical-legend mr-2 mb-2"
     >

--- a/web/src/components/LineagesByLocation.vue
+++ b/web/src/components/LineagesByLocation.vue
@@ -145,7 +145,7 @@ import { format } from 'd3-format';
 import { scaleLinear, scaleTime } from 'd3-scale';
 import { select, selectAll, event } from 'd3-selection';
 import { stack, area, stackOrderInsideOut } from 'd3-shape';
-import { timeMonth } from 'd3-time';
+import { timeSecond, timeMinute, timeHour, timeDay, timeWeek, timeMonth, timeYear  } from 'd3-time';
 import { timeParse, timeFormat } from 'd3-time-format';
 import { transition } from 'd3-transition';
 import cloneDeep from 'lodash/cloneDeep';
@@ -364,7 +364,17 @@ export default Vue.extend({
       );
 
       // reset the axis
-      this.xAxis = axisBottom(this.x).ticks(this.numXTicks);
+      this.xAxis = axisBottom(this.x)
+        .ticks(this.numXTicks)
+        .tickFormat(function(date){
+          return (timeSecond(date) < date ? timeFormat('.%L')
+            : timeMinute(date) < date ? timeFormat(':%S')
+            : timeHour(date) < date ? timeFormat('%I:%M')
+            : timeDay(date) < date ? timeFormat('%I %p')
+            : timeMonth(date) < date ? timeWeek(date) < date ? timeFormat('%a %d') : timeFormat('%b %d')
+            : timeYear(date) < date ? timeFormat('%b')
+            : timeFormat('%Y'))(date)
+        });
 
       select(this.$refs.xAxis).call(this.xAxis);
 
@@ -402,7 +412,18 @@ export default Vue.extend({
         .range([0, this.width - this.margin.left - this.margin.right])
         .domain(xDomain);
 
-      this.xAxis = axisBottom(this.x).tickSizeOuter(0).ticks(this.numXTicks);
+      this.xAxis = axisBottom(this.x)
+        .tickSizeOuter(0)
+        .ticks(this.numXTicks)
+        .tickFormat(function(date){
+          return (timeSecond(date) < date ? timeFormat('.%L')
+            : timeMinute(date) < date ? timeFormat(':%S')
+            : timeHour(date) < date ? timeFormat('%I:%M')
+            : timeDay(date) < date ? timeFormat('%I %p')
+            : timeMonth(date) < date ? timeWeek(date) < date ? timeFormat('%a %d') : timeFormat('%b %d')
+            : timeYear(date) < date ? timeFormat('%b')
+            : timeFormat('%Y'))(date)
+        });
 
       select(this.$refs.xAxis).call(this.xAxis);
 
@@ -897,24 +918,24 @@ export default Vue.extend({
 <style lang="scss">
 .lineages-by-location {
   .axis--x text {
-    font-size: 16pt;
+    font-size: 16px;
     @media (max-width: 812px) {
-      font-size: 8pt;
+      font-size: 12px;
     }
     @media (min-width: 812px) {
-      font-size: 8pt;
+      font-size: 12px;
     }
     @media (min-width: 900px) {
-      font-size: 10pt;
+      font-size: 14px;
     }
     @media (min-width: 1000px) {
-      font-size: 12pt;
+      font-size: 14px;
     }
     @media (min-width: 1200px) {
-      font-size: 14pt;
+      font-size: 16px;
     }
     @media (min-width: 1310px) {
-      font-size: 16pt;
+      font-size: 16px;
     }
   }
   .axis--y text {

--- a/web/src/components/LineagesByLocation.vue
+++ b/web/src/components/LineagesByLocation.vue
@@ -827,7 +827,7 @@ export default Vue.extend({
                 "'DM Sans', Avenir, Helvetica, Arial, sans-serif",
               )
               .style('dominant-baseline', 'text-top')
-              .style('font-size', '9pt');
+              .style('font-size', '14px');
           },
           (update) => {
             update

--- a/web/src/components/LineagesByLocation.vue
+++ b/web/src/components/LineagesByLocation.vue
@@ -918,28 +918,30 @@ export default Vue.extend({
     }
   }
   .axis--y text {
-    font-size: 9pt;
+    // font-size: 9pt;
+    font-size: 12px;
   }
   .stream-axis.axis--y text {
-    font-size: 14pt;
-    @media (max-width: 812px) {
-      font-size: 12pt;
-    }
-    @media (min-width: 812px) {
-      font-size: 10pt;
-    }
-    @media (min-width: 900px) {
-      font-size: 12pt;
-    }
-    @media (min-width: 1000px) {
-      font-size: 12pt;
-    }
-    @media (min-width: 1200px) {
-      font-size: 14pt;
-    }
-    @media (min-width: 1310px) {
-      font-size: 14pt;
-    }
+    // font-size: 14pt;
+    font-size: 16px;
+    // @media (max-width: 812px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 812px) {
+    //   font-size: 10pt;
+    // }
+    // @media (min-width: 900px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 1000px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 1200px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1310px) {
+    //   font-size: 14pt;
+    // }
   }
 }
 .suggest-note {

--- a/web/src/components/LineagesByLocation.vue
+++ b/web/src/components/LineagesByLocation.vue
@@ -938,31 +938,13 @@ export default Vue.extend({
       font-size: 16px;
     }
   }
+
   .axis--y text {
-    // font-size: 9pt;
     font-size: 12px;
   }
+  
   .stream-axis.axis--y text {
-    // font-size: 14pt;
     font-size: 16px;
-    // @media (max-width: 812px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 812px) {
-    //   font-size: 10pt;
-    // }
-    // @media (min-width: 900px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 1000px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 1200px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1310px) {
-    //   font-size: 14pt;
-    // }
   }
 }
 .suggest-note {

--- a/web/src/components/LineagesByLocation.vue
+++ b/web/src/components/LineagesByLocation.vue
@@ -13,7 +13,7 @@
       <h5 class="m-0">
         {{ plotTitle }}
       </h5>
-      <div class="d-flex justify-content-end align-items-center mt-3 mb-3">
+      <div class="d-flex justify-content-start align-items-start mt-3 mb-3">
         <button
           class="btn btn-accent-flat text-highlight d-flex align-items-center m-0 p-2 mr-2"
           @click="enableZoom"

--- a/web/src/components/LineagesByLocation.vue
+++ b/web/src/components/LineagesByLocation.vue
@@ -13,7 +13,7 @@
       <h5 class="m-0">
         {{ plotTitle }}
       </h5>
-      <div class="d-flex justify-content-end align-items-center mt-1">
+      <div class="d-flex justify-content-end align-items-center mt-3 mb-3">
         <button
           class="btn btn-accent-flat text-highlight d-flex align-items-center m-0 p-2 mr-2"
           @click="enableZoom"

--- a/web/src/components/LocationReportComponent.vue
+++ b/web/src/components/LocationReportComponent.vue
@@ -882,7 +882,7 @@
           class="my-5 py-3 border-top"
         >
           <div
-            class="d-flex flex-wrap align-items-center justify-content-center"
+            class="d-flex flex-wrap align-items-center justify-content-center mb-3"
           >
             <h3 class="mr-5">
               Tracked lineages

--- a/web/src/components/ReportPrevalenceOverlay.vue
+++ b/web/src/components/ReportPrevalenceOverlay.vue
@@ -42,22 +42,11 @@
       <!-- SVGs -->
       <div class="d-flex flex-column align-items-start">
         <!-- TIME TRACE -->
-        <div class="d-flex w-100 justify-content-between">
+        <div class="d-flex w-100 justify-content-between mb-2">
           <h5 class="p-0 m-0">
             {{ title }}
           </h5>
-          <div>
-            <label class="b-contain m-auto pr-3">
-              <small>show confidence intervals</small>
-              <input
-                v-model="showCI"
-                type="checkbox"
-                :value="showCI"
-                @change="hideCIs"
-              />
-              <div class="b-input" />
-            </label>
-          </div>
+          
         </div>
 
         <div class="d-flex mt-2">
@@ -85,6 +74,19 @@
           <small class="text-muted">missing recent data</small>
         </div>
 
+        <div class="d-flex mb-4">
+          <label class="b-contain m-auto pr-3">
+            <small>show confidence intervals</small>
+              <input
+                v-model="showCI"
+                type="checkbox"
+                :value="showCI"
+                @change="hideCIs"
+              />
+            <div class="b-input" />
+          </label>
+        </div>
+        
         <svg
           ref="svg"
           :width="width"
@@ -168,11 +170,11 @@
             id="weird-last values"
             :hidden="data && data.length < lengthThreshold"
           >
-            <text
+          <text
               :x="width - margin.right"
               :y="-1"
               fill="#929292"
-              font-size="14px"
+              font-size="13px"
               dominant-baseline="hanging"
               text-anchor="end"
               :style="`font-family: ${fontFamily};`"
@@ -180,6 +182,7 @@
               Latest dates are noisy due to fewer samples, or missing from
               sequencing delays
             </text>
+            
             <path
               stroke="#BBBBBB"
               fill="none"
@@ -244,7 +247,7 @@
         </div>
 
         <!-- EPI TRACE -->
-        <div :class="{ hidden: !epi.length }">
+        <div :class="{ hidden: !epi.length }" >
           <h5 class="">
             Daily COVID-19 cases in
             <router-link
@@ -253,7 +256,7 @@
               {{ locationName }}
             </router-link>
           </h5>
-          <div class="d-flex mb-2">
+          <div class="d-flex mt-3 mb-4">
             <svg width="15" height="15" class="mr-2">
               <line x1="0" x2="15" y1="8" y2="8" class="trace-legend" />
             </svg>
@@ -1163,7 +1166,7 @@ export default Vue.extend({
               .attr('x', this.width - this.margin.left - this.margin.right)
               .attr('dx', 5)
               .attr('y', (d) => d.y)
-              .style('font-size', 22)
+              .style('font-size', '16px')
               .style(
                 'font-family',
                 "'DM Sans', Avenir, Helvetica, Arial, sans-serif",

--- a/web/src/components/ReportPrevalenceOverlay.vue
+++ b/web/src/components/ReportPrevalenceOverlay.vue
@@ -1335,37 +1335,14 @@ export default Vue.extend({
     }
   }
 
-  // & .mutation-axis.axis--x text {
-  //   font-size: 16px;
-  // }
-
   & .mutation-axis.axis--y text {
     font-size: 16px;
-    // font-size: 16pt;
-    // @media (max-width: 812px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 812px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 900px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1000px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1200px) {
-    //   font-size: 16pt;
-    // }
-    // @media (min-width: 1310px) {
-    //   font-size: 16pt;
-    // }
-  }
-  & .epi-y.axis--y text {
-    // font-size: 14pt;
-    font-size: 16px;
   }
 
+  & .epi-y.axis--y text {
+    font-size: 16px;
+  }
+  
   & .epi-x {
     font-size: 16px;
     @media (max-width: 812px) {
@@ -1390,25 +1367,6 @@ export default Vue.extend({
 
   & .axis--y text {
     font-size: 12px;
-    // font-size: 12pt;
-    // @media (max-width: 812px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 812px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 900px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1000px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1200px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1310px) {
-    //   font-size: 16pt;
-    // }
   }
 
   & .axis--x line {

--- a/web/src/components/ReportPrevalenceOverlay.vue
+++ b/web/src/components/ReportPrevalenceOverlay.vue
@@ -5,7 +5,7 @@
   >
     <!-- zoom btns -->
     <div
-      class="d-flex justify-content-end px-3"
+      class="d-flex justify-content-end px-3 mt-3 mb-3"
       :style="{ width: width + 'px' }"
     >
       <button
@@ -206,7 +206,7 @@
 
         <!-- zoom btns -->
         <div
-          class="d-flex justify-content-end px-3"
+          class="d-flex justify-content-end px-3 mt-4 mb-3"
           :style="{ width: width + 'px' }"
           :class="{ hidden: !epi.length }"
         >

--- a/web/src/components/ReportPrevalenceOverlay.vue
+++ b/web/src/components/ReportPrevalenceOverlay.vue
@@ -3,9 +3,22 @@
     id="location-report-prevalence"
     class="d-flex flex-column align-items-center w-100"
   >
-    <!-- zoom btns -->
+    
+
+    <div class="d-flex flex-column">
+      <!-- SVGs -->
+      <div class="d-flex flex-column align-items-start">
+        <!-- TIME TRACE -->
+        <div class="d-flex w-100 justify-content-between mt-3 mb-2">
+          <h5 class="p-0 m-0">
+            {{ title }}
+          </h5>
+          
+        </div>
+
+        <!-- zoom btns -->
     <div
-      class="d-flex justify-content-end px-3 mt-3 mb-3"
+      class="d-flex justify-content-start ml-0 mt-2 mb-2"
       :style="{ width: width + 'px' }"
     >
       <button
@@ -37,17 +50,6 @@
         />
       </button>
     </div>
-
-    <div class="d-flex flex-column">
-      <!-- SVGs -->
-      <div class="d-flex flex-column align-items-start">
-        <!-- TIME TRACE -->
-        <div class="d-flex w-100 justify-content-between mb-2">
-          <h5 class="p-0 m-0">
-            {{ title }}
-          </h5>
-          
-        </div>
 
         <div class="d-flex mt-2">
           <svg width="15" height="15" class="mr-2">
@@ -207,14 +209,27 @@
           className="mutation-epi-prevalence"
         />
 
-        <!-- zoom btns -->
+        
+
+        <!-- EPI TRACE -->
+        <div class="mt-5" :class="{ hidden: !epi.length }" >
+          <h5 class="">
+            Daily COVID-19 cases in
+            <router-link
+              :to="{ name: 'Epidemiology', query: { location: locationID } }"
+            >
+              {{ locationName }}
+            </router-link>
+          </h5>
+
+          <!-- zoom btns -->
         <div
-          class="d-flex justify-content-end px-3 mt-4 mb-3"
+          class="d-flex justify-content-start mt-3 mb-3"
           :style="{ width: width + 'px' }"
           :class="{ hidden: !epi.length }"
         >
           <button
-            class="btn btn-accent-flat text-highlight d-flex align-items-center m-0 p-2"
+            class="btn btn-accent-flat text-highlight d-flex align-items-start m-0 p-2"
             @click="enableZoom"
           >
             <font-awesome-icon
@@ -246,16 +261,6 @@
           </button>
         </div>
 
-        <!-- EPI TRACE -->
-        <div :class="{ hidden: !epi.length }" >
-          <h5 class="">
-            Daily COVID-19 cases in
-            <router-link
-              :to="{ name: 'Epidemiology', query: { location: locationID } }"
-            >
-              {{ locationName }}
-            </router-link>
-          </h5>
           <div class="d-flex mt-3 mb-4">
             <svg width="15" height="15" class="mr-2">
               <line x1="0" x2="15" y1="8" y2="8" class="trace-legend" />

--- a/web/src/components/ReportPrevalenceOverlay.vue
+++ b/web/src/components/ReportPrevalenceOverlay.vue
@@ -347,7 +347,7 @@ import { forceY, forceCollide, forceSimulation } from 'd3-force';
 import { scaleLinear, scaleTime, scaleOrdinal } from 'd3-scale';
 import { select, selectAll, event } from 'd3-selection';
 import { area, line } from 'd3-shape';
-import { timeMonth } from 'd3-time';
+import { timeSecond, timeMinute, timeHour, timeDay, timeWeek, timeMonth, timeYear } from 'd3-time';
 import { timeParse, timeFormat } from 'd3-time-format';
 import { transition } from 'd3-transition';
 import cloneDeep from 'lodash/cloneDeep';
@@ -902,7 +902,16 @@ export default Vue.extend({
       this.xAxis = axisBottom(this.x)
         .ticks(this.numXTicks)
         .tickSize(-this.height)
-        .tickSizeOuter(0);
+        .tickSizeOuter(0)
+        .tickFormat(function(date){
+          return (timeSecond(date) < date ? timeFormat('.%L')
+            : timeMinute(date) < date ? timeFormat(':%S')
+            : timeHour(date) < date ? timeFormat('%I:%M')
+            : timeDay(date) < date ? timeFormat('%I %p')
+            : timeMonth(date) < date ? timeWeek(date) < date ? timeFormat('%a %d') : timeFormat('%b %d')
+            : timeYear(date) < date ? timeFormat('%b')
+            : timeFormat('%Y'))(date)
+        });     
 
       select(this.$refs.xAxis).call(this.xAxis);
       select(this.$refs.xEpiAxis).call(this.xAxis);
@@ -1293,30 +1302,34 @@ export default Vue.extend({
 #location-report-prevalence {
   & .count-axis,
   & .mutation-axis {
-    font-size: 16pt;
+    font-size: 16px;
     @media (max-width: 812px) {
-      font-size: 12pt;
+      font-size: 12px;
     }
     @media (min-width: 812px) {
-      font-size: 12pt;
+      font-size: 12px;
     }
     @media (min-width: 900px) {
-      font-size: 14pt;
+      font-size: 14px;
     }
     @media (min-width: 1000px) {
-      font-size: 14pt;
+      font-size: 14px;
     }
     @media (min-width: 1200px) {
-      font-size: 16pt;
+      font-size: 16px;
     }
     @media (min-width: 1310px) {
-      font-size: 16pt;
+      font-size: 16px;
     }
 
     text {
       fill: $grey-90;
     }
   }
+
+  // & .mutation-axis.axis--x text {
+  //   font-size: 16px;
+  // }
 
   & .mutation-axis.axis--y text {
     font-size: 16px;
@@ -1346,24 +1359,24 @@ export default Vue.extend({
   }
 
   & .epi-x {
-    font-size: 16pt;
+    font-size: 16px;
     @media (max-width: 812px) {
-      font-size: 12pt;
+      font-size: 12px;
     }
     @media (min-width: 812px) {
-      font-size: 12pt;
+      font-size: 12px;
     }
     @media (min-width: 900px) {
-      font-size: 14pt;
+      font-size: 14px;
     }
     @media (min-width: 1000px) {
-      font-size: 14pt;
+      font-size: 14px;
     }
     @media (min-width: 1200px) {
-      font-size: 16pt;
+      font-size: 16px;
     }
     @media (min-width: 1310px) {
-      font-size: 16pt;
+      font-size: 16px;
     }
   }
 

--- a/web/src/components/ReportPrevalenceOverlay.vue
+++ b/web/src/components/ReportPrevalenceOverlay.vue
@@ -60,7 +60,7 @@
           </div>
         </div>
 
-        <div class="d-flex">
+        <div class="d-flex mt-2">
           <svg width="15" height="15" class="mr-2">
             <line x1="0" x2="15" y1="8" y2="8" class="trace-legend" />
           </svg>
@@ -70,7 +70,7 @@
         </div>
 
         <!-- legend: confidence interval -->
-        <div class="d-flex">
+        <div class="d-flex mb-2">
           <div class="ci-legend mr-2" :style="{ background: '#999' }" />
           <small class="text-muted">95% confidence interval</small>
           <svg width="15" height="15" class="ml-4 mr-2">
@@ -170,7 +170,7 @@
           >
             <text
               :x="width - margin.right"
-              :y="0"
+              :y="-1"
               fill="#929292"
               font-size="14px"
               dominant-baseline="hanging"
@@ -253,7 +253,7 @@
               {{ locationName }}
             </router-link>
           </h5>
-          <div class="d-flex">
+          <div class="d-flex mb-2">
             <svg width="15" height="15" class="mr-2">
               <line x1="0" x2="15" y1="8" y2="8" class="trace-legend" />
             </svg>

--- a/web/src/components/ReportPrevalenceOverlay.vue
+++ b/web/src/components/ReportPrevalenceOverlay.vue
@@ -1319,28 +1319,30 @@ export default Vue.extend({
   }
 
   & .mutation-axis.axis--y text {
-    font-size: 16pt;
-    @media (max-width: 812px) {
-      font-size: 12pt;
-    }
-    @media (min-width: 812px) {
-      font-size: 12pt;
-    }
-    @media (min-width: 900px) {
-      font-size: 14pt;
-    }
-    @media (min-width: 1000px) {
-      font-size: 14pt;
-    }
-    @media (min-width: 1200px) {
-      font-size: 16pt;
-    }
-    @media (min-width: 1310px) {
-      font-size: 16pt;
-    }
+    font-size: 16px;
+    // font-size: 16pt;
+    // @media (max-width: 812px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 812px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 900px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1000px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1200px) {
+    //   font-size: 16pt;
+    // }
+    // @media (min-width: 1310px) {
+    //   font-size: 16pt;
+    // }
   }
-  & .epi-y {
-    font-size: 14pt;
+  & .epi-y.axis--y text {
+    // font-size: 14pt;
+    font-size: 16px;
   }
 
   & .epi-x {
@@ -1366,25 +1368,26 @@ export default Vue.extend({
   }
 
   & .axis--y text {
-    font-size: 12pt;
-    @media (max-width: 812px) {
-      font-size: 12pt;
-    }
-    @media (min-width: 812px) {
-      font-size: 12pt;
-    }
-    @media (min-width: 900px) {
-      font-size: 14pt;
-    }
-    @media (min-width: 1000px) {
-      font-size: 14pt;
-    }
-    @media (min-width: 1200px) {
-      font-size: 14pt;
-    }
-    @media (min-width: 1310px) {
-      font-size: 16pt;
-    }
+    font-size: 12px;
+    // font-size: 12pt;
+    // @media (max-width: 812px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 812px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 900px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1000px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1200px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1310px) {
+    //   font-size: 16pt;
+    // }
   }
 
   & .axis--x line {

--- a/web/src/components/ReportStackedBarGraph.vue
+++ b/web/src/components/ReportStackedBarGraph.vue
@@ -339,7 +339,8 @@ export default Vue.extend({
 
 .report-stacked-bar {
   .axis--y text {
-    font-size: 14pt;
+    // font-size: 14pt;
+    font-size: 16px;
   }
 }
 </style>

--- a/web/src/components/ReportStackedBarGraph.vue
+++ b/web/src/components/ReportStackedBarGraph.vue
@@ -339,7 +339,6 @@ export default Vue.extend({
 
 .report-stacked-bar {
   .axis--y text {
-    // font-size: 14pt;
     font-size: 16px;
   }
 }

--- a/web/src/components/SequencingHistogram.vue
+++ b/web/src/components/SequencingHistogram.vue
@@ -398,3 +398,9 @@ export default Vue.extend({
   },
 });
 </script>
+
+<style>
+.axis--y {
+  font-size: 12px;
+}
+</style>

--- a/web/src/components/SequencingHistogram.vue
+++ b/web/src/components/SequencingHistogram.vue
@@ -400,6 +400,10 @@ export default Vue.extend({
 </script>
 
 <style>
+.axis--x {
+  font-size: 12px;
+}
+
 .axis--y {
   font-size: 12px;
 }


### PR DESCRIPTION
This PR comprises small changes that address usability and aesthetic issues on the Location Tracker page:

- [Add white space between time buttons and other elements](https://github.com/outbreak-info/outbreak.info/commit/2f9648c5bac732e4c30631167d885c07d847d574)
- [Add white space between chart elements](https://github.com/outbreak-info/outbreak.info/commit/e313a6fa985b4291279eafe0a0dc1eb8e6ee8d43)
- [Add white space between tracked lineages table's headings and contents](https://github.com/outbreak-info/outbreak.info/commit/fd9447486cd8486843c89266b1ee1f85dd1c458e)
- [Adjust y-axes' font sizes](https://github.com/outbreak-info/outbreak.info/commit/f969025e344d648144d03880d05f3c9aeee57aec)
-  [Format x-axes' ticks](https://github.com/outbreak-info/outbreak.info/commit/1be119de2fb18c881ff39aec863ec0d8e4c18633)
- [Restyle chart elements](https://github.com/outbreak-info/outbreak.info/commit/04a268c455a16aa0420410b14b46304671c7a776)
- [Reposition time buttons](https://github.com/outbreak-info/outbreak.info/commit/201374539413a7126d14b2d4e7eee85215a70160)
- [Resize legend and histogram elements](https://github.com/outbreak-info/outbreak.info/commit/2a81f3884aa703cca2c2eda0938ddc13e1a748c2)
- [ Remove unneeded code](https://github.com/outbreak-info/outbreak.info/commit/9570dc4f8c53fcf44351bf8a351ff518c8a05187)
