### PR TITLE
Variant report UI improvements

### DIFF
--- a/web/src/components/ReportPrevalence.vue
+++ b/web/src/components/ReportPrevalence.vue
@@ -5,7 +5,7 @@
   >
     <!-- zoom btns -->
     <div
-      class="d-flex justify-content-end align-items-center px-3"
+      class="d-flex justify-content-start"
       :style="{ width: width + 'px' }"
     >
       <button
@@ -40,7 +40,7 @@
 
     <div class="d-flex flex-column">
       <!-- LEGEND -->
-      <div id="legend" class="d-flex flex-column ml-5 mt-3">
+      <div id="legend" class="d-flex flex-column mt-3">
         <!-- legend: rolling average -->
         <div class="d-flex">
           <svg width="15" height="15" class="mr-2">

--- a/web/src/components/ReportPrevalence.vue
+++ b/web/src/components/ReportPrevalence.vue
@@ -241,7 +241,7 @@ import { format } from 'd3-format';
 import { select, selectAll, event } from 'd3-selection';
 import { scaleLinear, scaleTime } from 'd3-scale';
 import { line, area } from 'd3-shape';
-import { timeDay, timeMonth } from 'd3-time';
+import { timeSecond, timeMinute, timeHour, timeDay, timeWeek, timeMonth, timeYear  } from 'd3-time';
 import { timeFormat, timeParse } from 'd3-time-format';
 import { transition } from 'd3-transition';
 import cloneDeep from 'lodash/cloneDeep';
@@ -454,7 +454,17 @@ export default Vue.extend({
       );
 
       // reset the axis
-      this.xAxis = axisBottom(this.x).ticks(this.numXTicks);
+      this.xAxis = axisBottom(this.x)
+        .ticks(this.numXTicks)
+        .tickFormat(function(date){
+          return (timeSecond(date) < date ? timeFormat('.%L')
+            : timeMinute(date) < date ? timeFormat(':%S')
+            : timeHour(date) < date ? timeFormat('%I:%M')
+            : timeDay(date) < date ? timeFormat('%I %p')
+            : timeMonth(date) < date ? timeWeek(date) < date ? timeFormat('%a %d') : timeFormat('%b %d')
+            : timeYear(date) < date ? timeFormat('%b')
+            : timeFormat('%Y'))(date)
+        });
 
       select(this.$refs.xAxis).call(this.xAxis);
 
@@ -511,7 +521,18 @@ export default Vue.extend({
         .domain([0, (avgMax + CIMax) * 0.5]);
       // .domain([0, max(this.data, d => d[this.yVariable])])
 
-      this.xAxis = axisBottom(this.x).ticks(this.numXTicks);
+      this.xAxis = axisBottom(this.x)
+        .ticks(this.numXTicks)
+        .tickFormat(function(date){
+          return (timeSecond(date) < date ? timeFormat('.%L')
+            : timeMinute(date) < date ? timeFormat(':%S')
+            : timeHour(date) < date ? timeFormat('%I:%M')
+            : timeDay(date) < date ? timeFormat('%I %p')
+            : timeMonth(date) < date ? timeWeek(date) < date ? timeFormat('%a %d') : timeFormat('%b %d')
+            : timeYear(date) < date ? timeFormat('%b')
+            : timeFormat('%Y'))(date)
+        });
+
       select(this.$refs.xAxis).call(this.xAxis);
 
       const yTickFormat = this.y.domain()[1] < 0.02 ? '.1%' : '.0%';

--- a/web/src/components/ReportPrevalence.vue
+++ b/web/src/components/ReportPrevalence.vue
@@ -170,7 +170,7 @@
               :x="width - margin.right"
               :y="-1"
               fill="#929292"
-              font-size="14px"
+              font-size="13px"
               dominant-baseline="hanging"
               text-anchor="end"
               :style="`font-family: ${fontFamily};`"

--- a/web/src/components/ReportPrevalence.vue
+++ b/web/src/components/ReportPrevalence.vue
@@ -869,25 +869,6 @@ export default Vue.extend({
 #report-prevalence-svg {
   & .mutation-axis,
   & .prevalence-axis {
-    // font-size: 16pt;
-    // @media (max-width: 664px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 664px) {
-    //   font-size: 12pt;
-    // }
-    // @media (min-width: 900px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1000px) {
-    //   font-size: 14pt;
-    // }
-    // @media (min-width: 1200px) {
-    //   font-size: 16pt;
-    // }
-    // @media (min-width: 1310px) {
-    //   font-size: 16pt;
-    // }
     font-size: 16px;
     @media (max-width: 664px) {
       font-size: 12px;

--- a/web/src/components/ReportPrevalence.vue
+++ b/web/src/components/ReportPrevalence.vue
@@ -848,24 +848,43 @@ export default Vue.extend({
 #report-prevalence-svg {
   & .mutation-axis,
   & .prevalence-axis {
-    font-size: 16pt;
+    // font-size: 16pt;
+    // @media (max-width: 664px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 664px) {
+    //   font-size: 12pt;
+    // }
+    // @media (min-width: 900px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1000px) {
+    //   font-size: 14pt;
+    // }
+    // @media (min-width: 1200px) {
+    //   font-size: 16pt;
+    // }
+    // @media (min-width: 1310px) {
+    //   font-size: 16pt;
+    // }
+    font-size: 16px;
     @media (max-width: 664px) {
-      font-size: 12pt;
+      font-size: 12px;
     }
     @media (min-width: 664px) {
-      font-size: 12pt;
+      font-size: 12px;
     }
     @media (min-width: 900px) {
-      font-size: 14pt;
+      font-size: 14px;
     }
     @media (min-width: 1000px) {
-      font-size: 14pt;
+      font-size: 14px;
     }
     @media (min-width: 1200px) {
-      font-size: 16pt;
+      font-size: 16px;
     }
     @media (min-width: 1310px) {
-      font-size: 16pt;
+      font-size: 16px;
     }
     text {
       fill: $grey-90;
@@ -884,6 +903,7 @@ export default Vue.extend({
   height: 15px;
   opacity: 0.3;
 }
+
 .trace-legend {
   stroke: $base-grey;
   stroke-width: 2.5;

--- a/web/src/components/ReportPrevalence.vue
+++ b/web/src/components/ReportPrevalence.vue
@@ -53,7 +53,7 @@
         </div>
 
         <!-- legend: confidence interval -->
-        <div class="d-flex align-items-center">
+        <div class="d-flex align-items-center mb-3">
           <div class="ci-legend mr-2" :style="{ background: CIColor }" />
           <small class="text-muted">95% confidence interval</small>
           <svg width="15" height="15" class="ml-4 mr-2">
@@ -168,7 +168,7 @@
           <g id="weird-last values" :hidden="data.length < lengthThreshold">
             <text
               :x="width - margin.right"
-              :y="0"
+              :y="-1"
               fill="#929292"
               font-size="14px"
               dominant-baseline="hanging"

--- a/web/src/components/SituationReportComponent.vue
+++ b/web/src/components/SituationReportComponent.vue
@@ -649,7 +649,7 @@
           <small class="text-muted mb-2">
             Based on reported sample collection date
           </small>
-          <div id="location-buttons" class="d-flex flex-wrap">
+          <div id="location-buttons" class="d-flex flex-wrap mb-3">
             <button
               v-for="(location, lIdx) in selectedLocations"
               :key="lIdx"


### PR DESCRIPTION
This PR comprises small changes that address usability and aesthetic issues on the Variant Report page. These changes keep charts' appearance consistent across pages as well:

- [[UPDATE] Add white space between UI elements](https://github.com/outbreak-info/outbreak.info/commit/26cc208f32bc7f4c4f342c38da8a94196774bf78)

- [[UPDATE] Reposition time buttons and legend](https://github.com/outbreak-info/outbreak.info/commit/ec956409219291788131be1ae6c6f08930aa2282)

- [[UPDATE] Adjust axes' font sizes](https://github.com/outbreak-info/outbreak.info/commit/dd7e083c7536324e4c17d0fa828b06d11eba5208)

- [[UPDATE] Format x-axis](https://github.com/outbreak-info/outbreak.info/commit/003cf4787a7fe2fddab9269d732d25ab80a455b5)

- [[UPDATE] Resize chart message](https://github.com/outbreak-info/outbreak.info/commit/66cbb1b9f65fd02348f0b65fb0ada8d671760c1e)

- [[UPDATE] Remove unneeded code](https://github.com/outbreak-info/outbreak.info/commit/d01b938f5bb48d91e9ee648d821064c0ba439e43)


