### PR TITLE
Prevent sparkline annotations from being clipped

### DIFF
--- a/web/src/components/GrOverview.vue
+++ b/web/src/components/GrOverview.vue
@@ -84,9 +84,9 @@
 
   const miniChartMargin = {
     top: 5,
-    right: 25,
+    right: 30,
     bottom: 25,
-    left: 25,
+    left: 30,
   };
 
   const miniChartWidth = computed(() => props.width * 0.3);


### PR DESCRIPTION
# Summary

This PR increases the svg margins so that sparkline annotations will not be clipped.