### PR TITLE
Feature/no ref/gr explainer improvement

### DIFF
--- a/web/src/components/GrNotes.vue
+++ b/web/src/components/GrNotes.vue
@@ -23,8 +23,11 @@
         altText="Growth rate chart comprising a scatterplot and a line-stripe chart. Chart elements are annotated."
       />
       <p>
-        A diverging <span class="bold">color scale</span> encodes growth rates. Shades of <span class="bold">yellow</span> correspond to mid-range growth rates, whereas dark <span class="bold">blue</span> and dark <span class="bold">red</span> are associated with low and high extremes, respectively. The middle value of the scale is 0%.
+        A diverging <span class="bold">color scale</span> encodes growth rates.
+        Dark <span class="bold">blue</span> and dark <span class="bold">red</span> are associated with extreme negative and positive growth rates, respectively. Shades of <span class="bold">yellow</span> correspond to mid-range growth rates. Yellow encodes the middle value of the scale, i.e. 0%. A 0% growth rate means that the lineage is neither growing nor shrinking compared to the background in a location.
       </p> 
+
+
       <GrImage 
         image="colorScale"
         altText="Growth rate chart in which the color scale is highlighted"
@@ -43,6 +46,9 @@
         image="lineStripeChart"
         altText="Growth rate chart in which the color scale and the line-stripe chart are highlighted"
       />
+      <p>
+        Hovering over charts causes <span class="bold">tooltips</span> to appear. Each tooltip presents information about the associated data point, namely growth rate and 95% CI, prevalence, number of lineage sequences, number of total sequences and ratio over background. The background is the difference between the number of total sequences and the number of lineage sequences divided by the number of lineage sequences.
+      </p>
       <h3>Data gaps</h3>
       <p>
         Growth rates are only calculated when a lineage is detected in sequence data from a location consistently over a one-week interval; as a result of limitations in sequencing coverage, gaps may exist in our growth-rates data estimates, especially for low-prevalence lineages. It is appropriate to assume that lineage growth rates vary continuously over time, and tend towards zero during sequencing gaps. 

--- a/web/src/views/GrowthRatesPage.vue
+++ b/web/src/views/GrowthRatesPage.vue
@@ -170,7 +170,6 @@
     align-items: center;
     height: 100%;
     width: 100%;
-    user-select: none;
   }
   .back-top {
     width: 150px;


### PR DESCRIPTION
# Summary

This PR adds information on the colour scale and tooltips and allows visitors to select and copy text from the growth rates page.