### PR TITLE
fix: remove outlier and snr filters, and add vertical padding

### DIFF
--- a/web/src/components/GrVisualizations.vue
+++ b/web/src/components/GrVisualizations.vue
@@ -209,7 +209,7 @@
     .domain(
       padExtent(
         [min(props.data,scatterplotYAccessor), max(props.data, scatterplotYAccessor)],
-        0.07,
+        0.55,
       )
     )
     .range([scatterplotInnerHeight, 0])

--- a/web/src/views/GrowthRatesPage.vue
+++ b/web/src/views/GrowthRatesPage.vue
@@ -75,10 +75,10 @@
   const locationsWithData = ref([]);
   const locationsWithoutData = ref([]);
  
-  const lowPercentile = 0.1;
-  const highPercentile = 0.9;
+  const lowPercentile = 0.0;
+  const highPercentile = 1.0;
 
-  const snrThreshold = 0.1;
+  const snrThreshold = 0.0;
 
   const isDataAggregated = ref(false);
 


### PR DESCRIPTION
# Summary

This PR removes outlier and signal-to-noise ratio filters and adds vertical padding to scatterplots. These changes reduce data gaps and clipped confidence interval bars.