### PR TITLE
fix: remove filter information from gr explainer

### DIFF
--- a/web/src/components/GrNotes.vue
+++ b/web/src/components/GrNotes.vue
@@ -53,12 +53,6 @@
       <p>
         Growth rates are only calculated when a lineage is detected in sequence data from a location consistently over a one-week interval; as a result of limitations in sequencing coverage, gaps may exist in our growth-rates data estimates, especially for low-prevalence lineages. It is appropriate to assume that lineage growth rates vary continuously over time, and tend towards zero during sequencing gaps. 
       </p>
-      <p>
-        Furthermore, only data points for which the absolute value of the ratio between the growth rate and the associated uncertainty is at least 0.1 are shown.
-      </p>
-      <p>
-        Gaps may also result from design choices as we remove outliers to keep the y-scale of the scatterplots constant and make growth rate variations over time more noticeable.
-      </p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Summary

This PR removes filter-related paragraphs from the **Data gaps** section of the growth rates page as filters are no longer used (please refer to PR #697 for more information). 