### PR TITLE
fix: show more results and sort them alphabetically

### DIFF
--- a/web/src/api/genomics.js
+++ b/web/src/api/genomics.js
@@ -1497,7 +1497,7 @@ export const findLocation = (apiurl, queryString, size = 10) => {
   );
 };
 
-export const findPangolin = (apiurl, queryString, size = 10) => {
+export const findPangolin = (apiurl, queryString, size = 15) => {
   const url = `${apiurl}lineage?name=*${queryString}*&size=${size}`;
 
   const vocs = CURATED.filter((d) => d.who_name).map((d) => ({
@@ -1522,6 +1522,8 @@ export const findPangolin = (apiurl, queryString, size = 10) => {
         d.name.toLowerCase().includes(queryString.toLowerCase()),
       );
       results = results.concat(filteredVocs);
+
+      if (results.length > 0) results.sort((a, b) => a.name.localeCompare(b.name));
 
       return results;
     }),

--- a/web/src/components/TypeaheadSelect.vue
+++ b/web/src/components/TypeaheadSelect.vue
@@ -121,8 +121,8 @@ const change = () => {
     querySubscription.value = props
       .queryFunction(props.apiUrl, selected.value)
       .subscribe((results) => {
-        if (results.length > 10) {
-          matches.value = results.slice(0, 10);
+        if (results.length > 15) {
+          matches.value = results.slice(0, 15);
         } else {
           matches.value = results;
         }


### PR DESCRIPTION
# Summary

This PR changes the way PANGO lineage results are shown:

- The maximum number of results is 15;
- Results are sorted alphabetically.