### PR TITLE
fix: show the beginning of the options list

### DIFF
--- a/web/src/components/GrForm.vue
+++ b/web/src/components/GrForm.vue
@@ -11,7 +11,7 @@
           placeholder="Type to search"
           :options="lineageOptions"
           clearable
-          :clear-filter-after-select="true"
+          :reset-menu-on-options-change=false
         />
       </n-form-item>
       <n-form-item 
@@ -26,7 +26,7 @@
           placeholder="Type to search"
           :options="locationOptions"
           clearable
-          :clear-filter-after-select="true"
+          :reset-menu-on-options-change=false
         />
       </n-form-item>
       <div class="query-buttons">


### PR DESCRIPTION
# Summary

This PR changes how **lineage** and **location** options are shown when visitors use selectors on the **growth rates page**.  

Previously, said options displayed items close to selected lineage and locations. This PR ensures the first items will be shown at all times. 