### PR TITLE
fix: enable svg copy

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -17,7 +17,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/solid.min.css">
     <script src="https://cdn.jsdelivr.net/clipboard.js/1.5.12/clipboard.min.js" defer></script>
     <script type="module" src="./src/main.js"></script>
-
+    <script>
+      if (global === undefined) {
+         var global = window;
+      }
+    </script>
   </head>
   <body class="bg-light">
     <noscript>


### PR DESCRIPTION
# Summary

This PR addresses a bug that prevents SVG images from being copied to the clipboard.